### PR TITLE
fix: correct import order in mcp.rs

### DIFF
--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -41,9 +41,9 @@
 use crate::config::McpServerConfig;
 use crate::error::{OxoError, Result};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 #[cfg(not(target_arch = "wasm32"))]
 use serde_json::json;
-use serde_json::Value;
 #[cfg(not(target_arch = "wasm32"))]
 use std::time::Duration;
 


### PR DESCRIPTION
## Description

Fix cargo fmt check failure by moving unconditional import `serde_json::Value` before conditional imports.

## Changes

- Move `use serde_json::Value;` above the `#[cfg(not(target_arch = "wasm32"))]` block

This ensures cargo fmt can properly order the imports.

## Related

Fixes CI format check failure.