### PR TITLE
docs: prioritize binary download in Quick Start section

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,34 @@ oxo-call is an AI-powered CLI assistant for bioinformatics. Instead of memorizin
 
 ## Quick Start
 
-### 1. Install
+### 1. Install (Recommended: Pre-built Binaries)
+
+The easiest way to install oxo-call is to download pre-built binaries from GitHub Releases:
+
+```bash
+# Linux/macOS
+curl -fsSL https://github.com/Traitome/oxo-call/releases/latest/download/oxo-call-linux-x86_64 -o oxo-call
+chmod +x oxo-call
+sudo mv oxo-call /usr/local/bin/
+
+# Or macOS (Apple Silicon)
+curl -fsSL https://github.com/Traitome/oxo-call/releases/latest/download/oxo-call-macos-aarch64 -o oxo-call
+chmod +x oxo-call
+sudo mv oxo-call /usr/local/bin/
+
+# Or Windows
+# Download from: https://github.com/Traitome/oxo-call/releases
+```
+
+See the [Installation guide](https://traitome.github.io/oxo-call/documentation/tutorials/installation.html) for all platforms and options.
+
+### Alternative: Install via Cargo
+
+If you have Rust installed, you can also install via cargo:
 
 ```bash
 cargo install oxo-call
 ```
-
-See the [Installation guide](https://traitome.github.io/oxo-call/documentation/tutorials/installation.html) for pre-built binaries and source builds.
 
 ### 2. Get a license
 


### PR DESCRIPTION
## Changes

- Recommend GitHub Releases pre-built binaries as the primary installation method
- Move cargo install to an alternative option
- Add download commands for Linux, macOS (Intel & Apple Silicon), and Windows

## Before

```
### 1. Install
cargo install oxo-call
```

## After

```
### 1. Install (Recommended: Pre-built Binaries)
# Download from GitHub Releases...

### Alternative: Install via Cargo
cargo install oxo-call
```

This makes it easier for users without Rust installed to get started quickly.