### PR TITLE
fix: resolve test race conditions and clap_complete compatibility

### DIFF
--- a/src/execution/feedback.rs
+++ b/src/execution/feedback.rs
@@ -223,10 +223,10 @@ mod tests {
 
     #[test]
     fn test_feedback_record_and_load() {
+        let _guard = crate::ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         // Use a temporary data dir to avoid clobbering real data.
         let tmp = tempfile::tempdir().unwrap();
-        // SAFETY: This test is single-threaded within its own tempdir and
-        // the env var is restored at the end.
+        // SAFETY: single-threaded access guaranteed by ENV_LOCK
         unsafe { std::env::set_var("OXO_CALL_DATA_DIR", tmp.path()) };
 
         let entry = FeedbackEntry {

--- a/src/help_cache.rs
+++ b/src/help_cache.rs
@@ -257,7 +257,7 @@ mod tests {
 
     #[test]
     fn test_put_and_get() {
-        let _lock = crate::ENV_LOCK.lock().unwrap();
+        let _lock = crate::ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         let tmp = tempfile::tempdir().unwrap();
         unsafe { std::env::set_var("OXO_CALL_DATA_DIR", tmp.path().to_string_lossy().as_ref()) };
 

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1179,7 +1179,7 @@ fn test_completion_all_shells() {
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
-        stdout.contains("_oxo-call"),
+        stdout.contains("_oxo__call") || stdout.contains("_oxo-call"),
         "Expected bash completion function name in output"
     );
     assert!(


### PR DESCRIPTION
## Summary

Fixes CI test failures in the \`Test (fmt, clippy, test)\` job.

## Root Causes

1. **Race condition on \`OXO_CALL_DATA_DIR\` env var**: \`test_feedback_record_and_load\` in \`src/execution/feedback.rs\` modified the \`OXO_CALL_DATA_DIR\` environment variable without acquiring \`ENV_LOCK\`. When this test ran concurrently with other tests that properly use the lock (e.g., \`test_list_cached_tools\`), the env var could be changed mid-operation, causing cached docs to be written to a wrong/deleted temp directory.

2. **Fragile \`unwrap()\` on poisoned mutex**: \`test_put_and_get\` in \`src/help_cache.rs\` used \`ENV_LOCK.lock().unwrap()\` instead of \`unwrap_or_else(|p| p.into_inner())\`. When any test panicked while holding \`ENV_LOCK\`, the mutex became poisoned and this test would also panic.

3. **clap_complete compatibility**: Newer versions of clap_complete generate bash function names by replacing hyphens with underscores (\`_oxo__call\` instead of \`_oxo-call\`). The completion test now accepts both formats.

## Changes

- \`src/execution/feedback.rs\`: Add \`ENV_LOCK\` acquisition to \`test_feedback_record_and_load\`
- \`src/help_cache.rs\`: Use \`unwrap_or_else\` for poisoned lock recovery
- \`tests/cli_tests.rs\`: Accept both \`_oxo__call\` and \`_oxo-call\` in completion test

🤖 Generated with [Claude Code](https://claude.com/claude-code)